### PR TITLE
Convert assert calls to error logs (NGWPC-7474)

### DIFF
--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -192,8 +192,18 @@ Update()
     LOG(bmilgar_ss.str(), LogLevel::INFO); bmilgar_ss.str("");  
   }
 
-  assert (state->lgar_bmi_input_params->precipitation_mm_per_h >= 0.0);
-  assert(state->lgar_bmi_input_params->PET_mm_per_h >=0.0);
+  if (state->lgar_bmi_input_params->precipitation_mm_per_h < 0.0) {
+    std::stringstream error_message;
+    error_message << "Pr [mm/h] is less than 0: " << state->lgar_bmi_input_params->precipitation_mm_per_h;
+    LOG(LogLevel::SEVERE, error_message.str());
+    throw std::runtime_error(error_message.str());
+  }
+  if (state->lgar_bmi_input_params->PET_mm_per_h < 0.0) {
+    std::stringstream error_message;
+    error_message << "PET [mm/h] is less than 0: " << state->lgar_bmi_input_params->PET_mm_per_h;
+    LOG(LogLevel::SEVERE, error_message.str());
+    throw std::runtime_error(error_message.str());
+  }
 
   // adaptive time step is set 
   if (adaptive_timestep) {
@@ -488,7 +498,13 @@ Update()
     // store local mass balance error to the struct
     state->lgar_mass_balance.local_mass_balance = local_mb;
 
-    assert (state->head->depth_cm > 0.0); // check on negative layer depth --> move this to somewhere else AJ (later)
+    // check on negative layer depth --> move this to somewhere else AJ (later)
+    if (state->head->depth_cm <= 0.0) {
+      std::stringstream error_message;
+      error_message << "Cycle " << cycle << " has a depth less than or equal to 0: " << state->head->depth_cm;
+      LOG(LogLevel::SEVERE, error_message.str());
+      throw std::runtime_error(error_message.str());
+    }
 
     bool lasam_standalone = true;
 #ifdef NGEN
@@ -519,7 +535,12 @@ Update()
   // update thickness/depth and soil moisture of wetting fronts (used for state coupling)
   struct wetting_front *current = state->head;
   for (int i=0; i<state->lgar_bmi_params.num_wetting_fronts; i++) {
-    assert (current != NULL);
+    if (current == NULL) {
+      std::stringstream error_message;
+      error_message << "Wetting front at index " << i << " is null.";
+      LOG(LogLevel::SEVERE, error_message.str());
+      throw std::runtime_error(error_message.str());
+    }
     state->lgar_bmi_params.soil_moisture_wetting_fronts[i] = current->theta;
     state->lgar_bmi_params.soil_depth_wetting_fronts[i] = current->depth_cm * state->units.cm_to_m;
     current = current->next;
@@ -577,7 +598,11 @@ Update()
 void BmiLGAR::
 UpdateUntil(double t)
 {
-  assert (t > 0.0);
+  if (t <= 0.0) {
+    const char *error_message = "Time must be greater than 0.";
+    LOG(LogLevel::SEVERE, error_message);
+    throw std::invalid_argument(error_message);
+  }
   this->Update();
 }
 
@@ -607,7 +632,12 @@ update_calibratable_parameters()
     layer_num  = current->layer_num;
     soil = state->lgar_bmi_params.layer_soil_type[layer_num];
     
-    assert (current != NULL);
+    if (current == NULL) {
+      std::stringstream error_message;
+      error_message << "Wetting front at index " << i << " is null.";
+      LOG(LogLevel::SEVERE, error_message.str());
+      throw std::invalid_argument(error_message.str());
+    }
 
     if (verbosity.compare("high") == 0 || verbosity.compare("low") == 0) {
       bmilgar_ss <<"----------- Calibratable parameters depending on soil layer (initial values) ----------- \n";

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -856,9 +856,12 @@ extern void frozen_factor_hydraulic_conductivity(struct lgar_bmi_parameters lgar
 	break;
     }
 
-
-    // assert (layer_temp > 100.0); // just a check to ensure the while loop executes at least once
-    assert (count > 0); // just a check to ensure the while loop executes at least once
+    if (count <= 0) { // just a check to ensure the while loop executes at least once
+      std::stringstream error_message;
+      error_message << "The count of layers used for getting layer " << layer << "'s temperature for frozen factor hydraulic conductivity is 0.";
+      LOG(LogLevel::SEVERE, error_message.str());
+      throw std::runtime_error(error_message.str());
+    }
 
     layer_temp /= count;  // layer-averaged temperature
 
@@ -991,6 +994,12 @@ extern void lgar_move_wetting_fronts(double timestep_h, double *volin_cm, int wf
 				     int *soil_type, double *frozen_factor, struct wetting_front** head,
 				     struct wetting_front* state_previous, struct soil_properties_ *soil_properties)
 {
+  if (old_mass <= 0.0) {
+    std::stringstream error_message;
+    error_message << "old_mass value must be greater than 0. Current value: " << old_mass;
+    LOG(LogLevel::SEVERE, error_message.str());
+    throw std::invalid_argument(error_message.str());
+  }
 
   if (verbosity.compare("high") == 0) {
     LOG(LogLevel::DEBUG,"State before moving wetting fronts...\n");
@@ -1358,8 +1367,6 @@ extern void lgar_move_wetting_fronts(double timestep_h, double *volin_cm, int wf
       struct wetting_front *wf_free_drainage = listFindFront(wf_free_drainage_demand, *head, NULL);
 
       double mass_timestep = (old_mass + precip_mass_to_add) - (actual_ET_demand + free_drainage_demand);
-
-      assert (old_mass > 0.0);
       
       if (fabs(wf_free_drainage->theta - theta_e_k1) < 1E-15) {
 	
@@ -1616,7 +1623,12 @@ extern void lgar_merge_wetting_fronts(int *soil_type, double *frozen_factor, str
       double current_mass_this_layer = current->depth_cm * (current->theta - next->theta) + next->depth_cm*(next->theta - next_to_next->theta);
       current->depth_cm = current_mass_this_layer / (current->theta - next_to_next->theta);
 
-      assert (current->depth_cm > 0.0);
+      if (current->depth_cm <= 0.0) {
+        std::stringstream error_message;
+        error_message << "Wetting front at index " << wf << " has a depth less than or equal to 0. Current value: " << current->depth_cm;
+        LOG(LogLevel::SEVERE, error_message.str());
+        throw std::runtime_error(error_message.str());
+      }
 
       layer_num = current->layer_num;
       soil_num  = soil_type[layer_num];
@@ -2356,7 +2368,15 @@ extern int lgar_read_vG_param_file(char const* vG_param_file_name, int num_soil_
       soil_properties[soil].bc_lambda  = 2.0 / (p - 3.0);
       soil_properties[soil].bc_psib_cm = (p + 3.0) * (147.8 + 8.1 * p + 0.092 * p * p) /
 	(2.0 * vg_alpha_per_cm * p * (p - 1.0) * (55.6 + 7.4 * p + p * p));
-      assert(0.0 < soil_properties[soil].bc_psib_cm);
+      if (soil_properties[soil].bc_psib_cm <= 0.0) {
+        std::stringstream error_message;
+        error_message << "Brooks & Corey bubbling pressure for soil index "
+          << soil << " (" << soil_properties[soil].soil_name
+          << ") must be greater than 0. Current value: " 
+          << soil_properties[soil].bc_psib_cm;
+        LOG(LogLevel::SEVERE, error_message.str());
+        throw std::runtime_error(error_message.str());
+      }
     }
     else {
       fprintf(stderr, "ERROR: van Genuchten parameter n must be greater than 1\n");

--- a/src/lgar.cxx
+++ b/src/lgar.cxx
@@ -100,7 +100,12 @@ extern void lgar_initialize(string config_file, struct model_state *state)
 
   struct wetting_front *current = state->head;
   for (int i=0; i<state->lgar_bmi_params.num_wetting_fronts; i++) {
-    assert (current != NULL);
+    if (current == NULL) {
+      std::stringstream error_message;
+      error_message << "Wetting front at index " << i << " is null.";
+      LOG(LogLevel::SEVERE, error_message.str());
+      throw std::runtime_error(error_message.str());
+    }
     
     soil = state->lgar_bmi_params.layer_soil_type[i+1];
 
@@ -433,7 +438,12 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
       else if (param_unit == "[h]" || param_unit == "[hr]")
 	      state->lgar_bmi_params.timestep_h /= 1.0; // convert to hours
 
-      assert (state->lgar_bmi_params.timestep_h > 0);
+      if (state->lgar_bmi_params.timestep_h <= 0) {
+        std::stringstream error_message;
+        error_message << "The timestep must be greater than 0. Current value in hours: " << state->lgar_bmi_params.timestep_h;
+        LOG(LogLevel::SEVERE, error_message.str());
+        throw std::runtime_error(error_message.str());
+      }
       is_timestep_set = true;
 
       state->lgar_bmi_params.minimum_timestep_h = state->lgar_bmi_params.timestep_h;
@@ -457,7 +467,12 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
       else if (param_unit == "[d]" || param_unit == "[day]")
 	      state->lgar_bmi_params.endtime_s = stod(param_value) * 86400.0;
 
-      assert (state->lgar_bmi_params.endtime_s > 0);
+      if (state->lgar_bmi_params.endtime_s <= 0) {
+        std::stringstream error_message;
+        error_message << "The end time must be greater than 0. Current value in seconds: " << state->lgar_bmi_params.endtime_s;
+        LOG(LogLevel::SEVERE, error_message.str());
+        throw std::runtime_error(error_message.str());
+      }
       is_endtime_set = true;
 
       if (verbosity.compare("high") == 0) {
@@ -478,7 +493,12 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
       else if (param_unit == "[h]" || param_unit == "[hr]")
 	      state->lgar_bmi_params.forcing_resolution_h /= 1.0;               // convert to hours
 
-      assert (state->lgar_bmi_params.forcing_resolution_h > 0);
+      if (state->lgar_bmi_params.forcing_resolution_h <= 0) {
+        std::stringstream error_message;
+        error_message << "The forcing resolution must be greater than 0. Current value in hours: " << state->lgar_bmi_params.forcing_resolution_h;
+        LOG(LogLevel::SEVERE, error_message.str());
+        throw std::runtime_error(error_message.str());
+      }
       is_forcing_resolution_set = true;
 
       if (verbosity.compare("high") == 0) {
@@ -727,7 +747,13 @@ extern void InitFromConfigFile(string config_file, struct model_state *state)
   state->lgar_bmi_params.nint               = 120; // hacked, not needed to be an input option
   state->lgar_bmi_params.num_wetting_fronts = state->lgar_bmi_params.num_layers;
 
-  assert (state->lgar_bmi_params.num_layers == listLength(state->head));
+  if (state->lgar_bmi_params.num_layers != listLength(state->head)) {
+    std::stringstream error_message;
+    error_message << "The number of wetting fronts in the configuration (" << state->lgar_bmi_params.num_layers
+      << ") is not the same as the number of wetting fronts created in memory (" << listLength(state->head) << ").";
+    LOG(LogLevel::SEVERE, error_message.str());
+    throw std::runtime_error(error_message.str());
+  }
 
   if (verbosity.compare("high") == 0) {
     lgar_ss <<"Initial ponded depth is set to zero. \n";


### PR DESCRIPTION
Convert assert calls that will give unhelpful error messages to error messages that will be logged through the Logger followed by exception throws.