### PR TITLE
Convert negative precipitation rates to 0 (NGWPC-7450)

### DIFF
--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -1089,6 +1089,16 @@ SetValue (std::string name, void *src)
   if (dest) {
     int nbytes = 0;
     nbytes = this->GetVarNbytes(name);
+    // catch negative numbers set for precipitation rate
+    if (name == "precipitation_rate") {
+      double candidate = *(double *)src;
+      if (candidate < 0.0) {
+        LOG(LogLevel::WARNING, "LASAM's precipitation rate was attempted to be set to a negative number: %f. The precipitation rate set will be changed to 0.", candidate);
+        double zero = 0.0;
+        memcpy(dest, &zero, nbytes);
+        return;
+      }
+    }
     memcpy(dest, src, nbytes);
   }
 


### PR DESCRIPTION
LASAM expects the set precipitation rate to be a positive number when Update() is called. It was noticed that snow17 may pass its melt and precipitation delta as a negative number to LASAM, causing LASAM to throw an error. The update prevents the error from being thrown by checking if the incoming precipitation rate is less than 0 and interprets it as 0 instead.

## Additions

- Convert negative precipitation rates to 0 in SetValue.
- Warning level log when the value is set to 0 to record what the original value is.

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
