### PR TITLE
Adapt serialization to revised protocol

### DIFF
--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -792,6 +792,7 @@ GetVarGrid(std::string name)
     return 5;
   else if (
     name.compare("serialization_create") == 0
+    || name.compare("serialization_size") == 0
   ) // uint64_t
     return 6;
   else
@@ -943,7 +944,7 @@ GetGridRank(const int grid)
 int BmiLGAR::
 GetGridSize(const int grid)
 {
-  if (grid == 0 || grid == 1)
+  if (grid == 0 || grid == 1 || grid == 6)
     return 1;
   else if (grid == 2) // number of layers (fixed)
     return this->state->lgar_bmi_params.num_layers;
@@ -966,13 +967,8 @@ GetValue (std::string name, void *dest)
   int nbytes = 0;
 
   src = this->GetValuePtr(name);
-
-  if (name.compare("serialization_state") == 0) {
-    memcpy(dest, src, this->m_serialized_length);
-  } else {
-    nbytes = this->GetVarNbytes(name);
-    memcpy (dest, src, nbytes);
-  }
+  nbytes = this->GetVarNbytes(name);
+  memcpy (dest, src, nbytes);
 }
 
 
@@ -1031,8 +1027,7 @@ GetValuePtr (std::string name)
     return (void*)&this->state->lgar_calib_params.field_capacity_psi;
   else if (name.compare("serialization_state") == 0)
     return (void*)(this->m_serialized.data());
-  else if (name.compare("serialization_create") == 0) {
-    this->new_serialized();
+  else if (name.compare("serialization_size") == 0) {
     return (void*)(&this->m_serialized_length);
   } else {
     std::stringstream errMsg;
@@ -1079,9 +1074,8 @@ SetValue (std::string name, void *src)
     this->free_serialized();
     return;
   } else if (name.compare("serialization_create") == 0) {
-    auto msg = "Cannot set values with \"serialization_create\".";
-    Logger::Log(LogLevel::WARNING, msg);
-    throw std::runtime_error(msg);
+    this->new_serialized();
+    return;
   }
   void * dest = NULL;
   dest = this->GetValuePtr(name);


### PR DESCRIPTION
The earlier BMI state saving protocol was not going to be tenable on Fortran due to intent(in) dummy arguments. This revision simplifies the protocol such that SetValue is used for mutating actions, and GetValue/GetValuePtr are used for queries.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: