### PR TITLE
Add NWM Ponded Depth (NGWPC-9175)

### DIFF
--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -21,6 +21,8 @@ extern "C" {
 #include "../giuh/giuh.h"
 }
 
+#define NWM_PONDED_DEPTH_OUT_VAR "nwm_ponded_depth"
+
 namespace bmi_lgar {
 class NotImplemented : public std::logic_error {
   public:
@@ -58,6 +60,7 @@ public:
     this->output_var_names[12] = "percolation";
     this->output_var_names[13] = "groundwater_to_stream_recharge";
     this->output_var_names[14] = "mass_balance";
+    this->output_var_names[15] = NWM_PONDED_DEPTH_OUT_VAR;
     
     /*
     this->output_var_names[13] = "cum_precipitation";
@@ -142,7 +145,7 @@ private:
   void realloc_soil();
   struct model_state* state;
   static const int input_var_name_count  = 3;
-  static const int output_var_name_count = 15;
+  static const int output_var_name_count = 16;
   static const int calib_var_name_count  = 7;
   
   std::string input_var_names[input_var_name_count];
@@ -166,6 +169,7 @@ private:
     double volrech_timestep_m;
     double volrunoff_timestep_m;
     double volrunoff_giuh_timestep_m;
+    double volrunoff_guih_ponded_m;
     double volQ_timestep_m;
     double volQ_gw_timestep_m;
     double volPET_timestep_m;

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -169,7 +169,7 @@ private:
     double volrech_timestep_m;
     double volrunoff_timestep_m;
     double volrunoff_giuh_timestep_m;
-    double volrunoff_guih_ponded_m;
+    double volrunoff_giuh_ponded_m;
     double volQ_timestep_m;
     double volQ_gw_timestep_m;
     double volPET_timestep_m;

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -121,7 +121,7 @@ Update()
     bmi_unit_conv.volQ_gw_timestep_m    = 0.0;
     bmi_unit_conv.volPET_timestep_m     = 0.0;
     bmi_unit_conv.volrunoff_giuh_timestep_m = 0.0;
-    bmi_unit_conv.volrunoff_guih_ponded_m = 0.0;
+    bmi_unit_conv.volrunoff_giuh_ponded_m = 0.0;
 
     return;
   }
@@ -598,7 +598,7 @@ Update()
   bmi_unit_conv.volQ_gw_timestep_m    = volQ_gw_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volPET_timestep_m     = PET_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volrunoff_giuh_timestep_m = volrunoff_giuh_timestep_cm * state->units.cm_to_m;
-  bmi_unit_conv.volrunoff_guih_ponded_m = volrunoff_giuh_ponded_cm * state->units.cm_to_m;
+  bmi_unit_conv.volrunoff_giuh_ponded_m = volrunoff_giuh_ponded_cm * state->units.cm_to_m;
 }
 
 
@@ -1010,7 +1010,7 @@ GetValuePtr (std::string name)
   else if (name.compare("mass_balance") == 0)
     return (void*)(&bmi_unit_conv.mass_balance_m);
   else if (name.compare(NWM_PONDED_DEPTH_OUT_VAR) == 0)
-    return (void*)(&this->bmi_unit_conv.volrunoff_guih_ponded_m);
+    return (void*)(&this->bmi_unit_conv.volrunoff_giuh_ponded_m);
   else if (name.compare("soil_depth_layers") == 0)
     return (void*)this->state->lgar_bmi_params.cum_layer_thickness_cm;  // this too and, if needed, change soil_moisture_layers to soil_thickness_layers
   else if (name.compare("soil_moisture_wetting_fronts") == 0)
@@ -1326,7 +1326,7 @@ serialize(Archive& ar, const unsigned int version) {
   ar & this->bmi_unit_conv.volQ_gw_timestep_m;
   ar & this->bmi_unit_conv.mass_balance_m;
   ar & this->bmi_unit_conv.volrunoff_timestep_m;
-  ar & this->bmi_unit_conv.volrunoff_guih_ponded_m;
+  ar & this->bmi_unit_conv.volrunoff_giuh_ponded_m;
   ar & state->lgar_bmi_params.num_wetting_fronts;
   ar & state->lgar_calib_params.ponded_depth_max;
   ar & state->lgar_calib_params.field_capacity_psi;

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -121,6 +121,7 @@ Update()
     bmi_unit_conv.volQ_gw_timestep_m    = 0.0;
     bmi_unit_conv.volPET_timestep_m     = 0.0;
     bmi_unit_conv.volrunoff_giuh_timestep_m = 0.0;
+    bmi_unit_conv.volrunoff_guih_ponded_m = 0.0;
 
     return;
   }
@@ -153,6 +154,7 @@ Update()
   double volrech_timestep_cm        = 0.0;
   double surface_runoff_timestep_cm = 0.0; // direct surface runoff
   double volrunoff_giuh_timestep_cm = 0.0;
+  double volrunoff_giuh_ponded_cm   = 0.0;
   double volQ_timestep_cm           = 0.0;
   double volQ_gw_timestep_cm        = 0.0;
   
@@ -523,6 +525,11 @@ Update()
   // when groundwater component is added, it should probably happen inside of the subcycling loop.
   volQ_timestep_cm = volrunoff_giuh_timestep_cm;
 
+  // calculate compounded runoff
+  for (int i = 0; i < num_giuh_ordinates; ++i) {
+    volrunoff_giuh_ponded_cm += giuh_runoff_queue[i];
+  }
+
   /*----------------------------------------------------------------------*/
   // Everything related to lgar state is done at this point, now time to update some dynamic variables
 
@@ -591,7 +598,7 @@ Update()
   bmi_unit_conv.volQ_gw_timestep_m    = volQ_gw_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volPET_timestep_m     = PET_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volrunoff_giuh_timestep_m = volrunoff_giuh_timestep_cm * state->units.cm_to_m;
-  
+  bmi_unit_conv.volrunoff_guih_ponded_m = volrunoff_giuh_ponded_cm * state->units.cm_to_m;
 }
 
 
@@ -765,6 +772,7 @@ GetVarGrid(std::string name)
 	  || name.compare("percolation") == 0
     || name.compare("groundwater_to_stream_recharge") == 0
     || name.compare("mass_balance") == 0
+    || name.compare(NWM_PONDED_DEPTH_OUT_VAR) == 0
   ) // double
     return 1;
   else if (
@@ -845,7 +853,7 @@ GetVarUnits(std::string name)
 	   || name.compare("actual_evapotranspiration") == 0) // double
     return "m";
   else if (name.compare("surface_runoff") == 0 || name.compare("giuh_runoff") == 0
-	   || name.compare("soil_storage") == 0) // double
+	   || name.compare("soil_storage") == 0 || name.compare(NWM_PONDED_DEPTH_OUT_VAR) == 0) // double
     return "m";
   else if (name.compare("total_discharge") == 0 || name.compare("infiltration") == 0
 	   || name.compare("percolation") == 0) // double
@@ -884,7 +892,7 @@ GetVarLocation(std::string name)
       || name.compare("actual_evapotranspiration") == 0) // double
     return "node";
   else if (name.compare("surface_runoff") == 0 || name.compare("giuh_runoff") == 0
-	   || name.compare("soil_storage") == 0) // double
+	   || name.compare("soil_storage") == 0 || name.compare(NWM_PONDED_DEPTH_OUT_VAR)) // double
     return "node";
    else if (name.compare("total_discharge") == 0 || name.compare("infiltration") == 0
 	    || name.compare("percolation") == 0 || name.compare("groundwater_to_stream_recharge") == 0) // double
@@ -1001,6 +1009,8 @@ GetValuePtr (std::string name)
     return (void*)(&bmi_unit_conv.volQ_gw_timestep_m);
   else if (name.compare("mass_balance") == 0)
     return (void*)(&bmi_unit_conv.mass_balance_m);
+  else if (name.compare(NWM_PONDED_DEPTH_OUT_VAR) == 0)
+    return (void*)(&this->bmi_unit_conv.volrunoff_guih_ponded_m);
   else if (name.compare("soil_depth_layers") == 0)
     return (void*)this->state->lgar_bmi_params.cum_layer_thickness_cm;  // this too and, if needed, change soil_moisture_layers to soil_thickness_layers
   else if (name.compare("soil_moisture_wetting_fronts") == 0)
@@ -1316,6 +1326,7 @@ serialize(Archive& ar, const unsigned int version) {
   ar & this->bmi_unit_conv.volQ_gw_timestep_m;
   ar & this->bmi_unit_conv.mass_balance_m;
   ar & this->bmi_unit_conv.volrunoff_timestep_m;
+  ar & this->bmi_unit_conv.volrunoff_guih_ponded_m;
   ar & state->lgar_bmi_params.num_wetting_fronts;
   ar & state->lgar_calib_params.ponded_depth_max;
   ar & state->lgar_calib_params.field_capacity_psi;


### PR DESCRIPTION
This change adds as a CFE `NWM_PONDED_DEPTH` calculation to LASAM. The output variable name is lowercase for LASAM for consistency with LASAM's variables and to prevent multiple BMIs from sharing the same output variable names (something that can cause problems in `Multi_Bmi_Formulations`.

CFE calculates the ponded runoff as the sum of the giuh runoff queue during it's `Update` method. LASAM will now replicate this method.

## Additions

- `bmi_unit_conversion::volrunoff_guih_ponded_m` `double` value added for storing the calculation.
- `BmiLGAR::Update` computes the ponded value and assigns it.

## Removals

-

## Changes

- `BmiLGAR::serialize` accounts for this value.
- `BmiLGAR::output_var_names` has its size increased and `"nwm_ponded_depth"` added.
- `BmiLGAR` variables methods `GetVarGrid`, `GetVarUnits`, `GetVarLocation`, and `GetValuePtr` updated to look for `"nwm_ponded_depth"`.

## Testing

1.

## Screenshots


## Notes

- The default value of `bmi_unit_conversion::volrunoff_guih_ponded_m` is not defined in creation or initialization from config file, just like all other `bmi_unit_conversion` values.

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
