### PR TITLE
Add GetLogLevel method to Logger source file

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -279,10 +279,6 @@ void Logger::SetLoggingFlag(void) {
     std::cout << MODULE_NAME << " Logging " << ((loggingEnabled)?"ENABLED":"DISABLED") << std::endl;
 }
 
-bool Logger::IsLoggingEnabled(void) {
-    return loggingEnabled;
-}
-
 void Logger::SetLogModuleName(void) {
     // Make sure the module name used for logging entries is all uppercase and 8 characters wide.
     moduleName            = MODULE_NAME;
@@ -418,3 +414,11 @@ std::string Logger::CreateTimestamp(bool appendMS, bool iso) {
 std::string Logger::GetLogFilePath() {
     return logFilePath;
 }
+
+bool Logger::IsLoggingEnabled(void) {
+    return loggingEnabled;
+}
+
+LogLevel Logger::GetLogLevel(void) {
+    return logLevel;
+} 


### PR DESCRIPTION
The GetLogLevel method was declared in the Logger.hpp file but not defined in the Logger.cpp file.

## Additions

- Added GetLogLevel method definition in Logger source file

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests

