### PR TITLE
Implement reset_time message (NGWPC-9618)

### DIFF
--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -184,7 +184,7 @@ private:
   void serialize_wetting_front_list(Archive &ar, wetting_front **head, int &count);
   
   void new_serialized();
-  void load_serialized(const char* data);
+  void load_serialized(char* data);
   void free_serialized();
 };
 

--- a/include/vecbuf.hpp
+++ b/include/vecbuf.hpp
@@ -28,6 +28,9 @@ public:
     // Forwarder for std::vector::clear()
     constexpr void clear() { vector_.clear(); }
 
+    // Forwarder for std::vector::resize(size)
+    constexpr void resize(size_type size) { vector_.resize(size); }
+
     // Forwarder for std::vector::reserve
     constexpr void reserve(size_type capacity) { vector_.reserve(capacity); setp_from_vector(); }
 
@@ -35,7 +38,7 @@ public:
     constexpr void reserve_additional(size_type additional_capacity) { reserve(size() + additional_capacity); }
 
     // Forwarder for std::vector::data
-    constexpr const value_type* data() const { return vector_.data(); }
+    constexpr value_type* data() { return vector_.data(); }
 
     // Forwarder for std::vector::size
     constexpr size_type size() const { return vector_.size(); }
@@ -110,6 +113,13 @@ private:
         return written;
     }
 
+};
+
+class membuf : public std::streambuf {
+public:
+    membuf(char *begin, size_t size) {
+        this->setg(begin, begin, begin + size);
+    }
 };
 
 #endif

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -773,6 +773,7 @@ GetVarGrid(std::string name)
     || name.compare("groundwater_to_stream_recharge") == 0
     || name.compare("mass_balance") == 0
     || name.compare(NWM_PONDED_DEPTH_OUT_VAR) == 0
+    || name.compare("reset_time") == 0
   ) // double
     return 1;
   else if (
@@ -1085,6 +1086,11 @@ SetValue (std::string name, void *src)
     return;
   } else if (name.compare("serialization_create") == 0) {
     this->new_serialized();
+    return;
+  } else if (name.compare("reset_time") == 0) {
+    // time_s and timesteps seems to be used exclusively for reporting current time
+    this->state->lgar_bmi_params.time_s = this->GetStartTime();
+    this->state->lgar_bmi_params.timesteps = 0;
     return;
   }
   void * dest = NULL;

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -1436,11 +1436,15 @@ void BmiLGAR::serialize_wetting_front_list(Archive &ar, wetting_front **head, in
 }
 
 void BmiLGAR::new_serialized() {
-  this->m_serialized.clear();
+  // resize with reserved space for storing size
+  this->m_serialized.resize(sizeof(uint64_t));
   boost::archive::binary_oarchive archive(this->m_serialized);
   try {
     archive << (*this);
     this->m_serialized_length = this->m_serialized.size();
+    // get serialized size without header and copy size to the beginning of the buffer
+    uint64_t serialized_size = this->m_serialized_length - sizeof(uint64_t);
+    memcpy(this->m_serialized.data(), &serialized_size, sizeof(uint64_t));
   } catch (const std::exception &e) {
     Logger::Log(LogLevel::SEVERE, "Serializing LASAM encountered an error: %s", e.what());
     this->free_serialized();
@@ -1448,8 +1452,12 @@ void BmiLGAR::new_serialized() {
   }
 }
 
-void BmiLGAR::load_serialized(const char* data) {
-  std::stringstream stream(data);
+void BmiLGAR::load_serialized(char* data) {
+  // copy size from the start of data
+  uint64_t size;
+  memcpy(&size, data, sizeof(uint64_t));
+  // create stream from everything past the size header
+  membuf stream(data + sizeof(uint64_t), size);
   boost::archive::binary_iarchive archive(stream);
   try {
     archive >> (*this);


### PR DESCRIPTION
Hindcasting requires resetting a BMI to time 0 after loading a state. This implements the message `"reset_time"` for signaling to the BMI that it should set its time to 0.

## Changes

- `SetValue` includes an option for `"reset_time"` that sets the model's time and timesteps to 0. These are sufficient for resetting time for this BMI.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
