### PR TITLE
Adding Precipitation Rate Output

### DIFF
--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -61,7 +61,7 @@ public:
     this->output_var_names[13] = "groundwater_to_stream_recharge";
     this->output_var_names[14] = "mass_balance";
     this->output_var_names[15] = NWM_PONDED_DEPTH_OUT_VAR;
-    this->output_var_names[15] = "precipitation_rate_out"
+    this->output_var_names[16] = "precipitation_rate_out";
     
     /*
     this->output_var_names[13] = "cum_precipitation";

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -61,6 +61,7 @@ public:
     this->output_var_names[13] = "groundwater_to_stream_recharge";
     this->output_var_names[14] = "mass_balance";
     this->output_var_names[15] = NWM_PONDED_DEPTH_OUT_VAR;
+    this->output_var_names[15] = "precipitation_rate_out"
     
     /*
     this->output_var_names[13] = "cum_precipitation";
@@ -145,7 +146,7 @@ private:
   void realloc_soil();
   struct model_state* state;
   static const int input_var_name_count  = 3;
-  static const int output_var_name_count = 16;
+  static const int output_var_name_count = 17;
   static const int calib_var_name_count  = 7;
   
   std::string input_var_names[input_var_name_count];

--- a/realizations/realization_config_lasam.json
+++ b/realizations/realization_config_lasam.json
@@ -17,6 +17,7 @@
 			"main_output_variable": "total_discharge",
 			"output_variables" : [
 			    "precipitation",
+			    "precipitation_rate_out",
 			    "potential_evapotranspiration",
 			    "actual_evapotranspiration",
 			    "surface_runoff",

--- a/realizations/realization_config_lasam_sft.json
+++ b/realizations/realization_config_lasam_sft.json
@@ -17,6 +17,7 @@
 			"main_output_variable": "total_discharge",
 			"output_variables" : [
 			    "precipitation",
+			    "precipitation_rate_out",
 			    "potential_evapotranspiration",
 			    "actual_evapotranspiration",
 			    "surface_runoff",

--- a/realizations/realization_config_lasam_smp.json
+++ b/realizations/realization_config_lasam_smp.json
@@ -17,6 +17,7 @@
 			"main_output_variable": "total_discharge",
 			"output_variables" : [
 			    "precipitation",
+			    "precipitation_rate_out",
 			    "potential_evapotranspiration",
 			    "actual_evapotranspiration",
 			    "surface_runoff",

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -758,6 +758,7 @@ GetVarGrid(std::string name)
     return 0;
   else if (
     name.compare("precipitation_rate") == 0
+    || name.compare("precipitation_rate_out") == 0
     || name.compare("precipitation") == 0
     || name.compare("potential_evapotranspiration_rate") == 0
     || name.compare("potential_evapotranspiration") == 0
@@ -847,7 +848,8 @@ GetVarItemsize(std::string name)
 std::string BmiLGAR::
 GetVarUnits(std::string name)
 {
-  if (name.compare("precipitation_rate") == 0 || name.compare("potential_evapotranspiration_rate") == 0)
+  if (name.compare("precipitation_rate") == 0 || name.compare("precipitation_rate_out") == 0 
+           || name.compare("potential_evapotranspiration_rate") == 0)
     return "mm h^-1";
   else if (name.compare("precipitation") == 0 || name.compare("potential_evapotranspiration") == 0
 	   || name.compare("actual_evapotranspiration") == 0) // double
@@ -887,9 +889,11 @@ GetVarNbytes(std::string name)
 std::string BmiLGAR::
 GetVarLocation(std::string name)
 {
-  if (name.compare("precipitation_rate") == 0 || name.compare("precipitation") == 0 ||
-      name.compare("potential_evapotranspiration") == 0 || name.compare("potential_evapotranspiration_rate") == 0
-      || name.compare("actual_evapotranspiration") == 0) // double
+  if (name.compare("precipitation_rate") == 0 || name.compare("precipitation_rate_out") == 0 ||
+    name.compare("precipitation") == 0 ||
+    name.compare("potential_evapotranspiration") == 0 ||
+    name.compare("potential_evapotranspiration_rate") == 0 ||
+    name.compare("actual_evapotranspiration") == 0)
     return "node";
   else if (name.compare("surface_runoff") == 0 || name.compare("giuh_runoff") == 0
 	   || name.compare("soil_storage") == 0 || name.compare(NWM_PONDED_DEPTH_OUT_VAR)) // double
@@ -984,6 +988,8 @@ void *BmiLGAR::
 GetValuePtr (std::string name)
 {
   if (name.compare("precipitation_rate") == 0)
+    return (void*)(&this->state->lgar_bmi_input_params->precipitation_mm_per_h);
+  else if (name.compare("precipitation_rate_out") == 0)
     return (void*)(&this->state->lgar_bmi_input_params->precipitation_mm_per_h);
   else if (name.compare("precipitation") == 0)
     return (void*)(&bmi_unit_conv.volprecip_timestep_m);

--- a/src/bmi_main_lgar.cxx
+++ b/src/bmi_main_lgar.cxx
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
   std::string var_name_wf     = "soil_moisture_wetting_fronts";
   std::string var_name_thickness_wf = "soil_depth_wetting_fronts";
 
-  int num_output_var = 11;
+  int num_output_var = 12;
   std::vector<std::string> output_var_names(num_output_var);
   std::vector<double> output_var_data(num_output_var);
 
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
   output_var_names[8]  = "percolation";
   output_var_names[9]  = "groundwater_to_stream_recharge";
   output_var_names[10] = "mass_balance";
-
+  output_var_names[11] = "precipitation_rate_out";
 
   // total number of timesteps
 

--- a/tests/main_unit_test_bmi.cxx
+++ b/tests/main_unit_test_bmi.cxx
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
   int num_wetting_fronts = 3;       // total number of wetting fronts
   bool test_status       = true;    // unit test status flag, if test fail the flag turns false
   int num_input_vars     = 3;       // total number of bmi input variables
-  int num_output_vars    = 15;      // total number of bmi output variables
+  int num_output_vars    = 16;      // total number of bmi output variables
 
   // *************************************************************************************
   // names of the bmi input/output variables and the corresponding sizes, with units of input variables
@@ -59,13 +59,13 @@ int main(int argc, char *argv[])
 					       "actual_evapotranspiration", "surface_runoff",
 					       "giuh_runoff", "soil_storage", "total_discharge",
 					       "infiltration", "percolation", "groundwater_to_stream_recharge",
-					       "mass_balance"};
+					       "mass_balance", "precipitation_rate_out"};
 
   int nbytes_input[] = {sizeof(double), sizeof(double), sizeof(double)};
   int nbytes_output[] = {int(num_wetting_fronts * sizeof(double)), int(num_layers * sizeof(double)),
 			 int(num_wetting_fronts * sizeof(double)), sizeof(int), sizeof(double),
 			 sizeof(double), sizeof(double), sizeof(double), sizeof(double), sizeof(double),
-			 sizeof(double), sizeof(double), sizeof(double), sizeof(double), sizeof(double)};
+			 sizeof(double), sizeof(double), sizeof(double), sizeof(double), sizeof(double), sizeof(double)};
 
   std::vector<std::string> bmi_units = {"mm h^-1", "mm h^-1", "K"};
   // *************************************************************************************


### PR DESCRIPTION
Based on story: https://jira.nextgenwaterprediction.com/browse/NGWPC-9963.
Review and update as necessary the rainfall runoff models (CFE, LASAM, TOPMODEL, SAC-SMA) to assure they are generating consistent output of liquid water input in a consistent output variable that can be converted to appropriate units for display in ngenCERF

Coordinate as needed with MSWM configurations. 

Created new Output Variable: precipitation_rate_out, which is same as input precipitation_rate
Made changes to other files to reflect that chnage

-

## Testing

https://confluence.nextgenwaterprediction.com/spaces/NGWPC/pages/90177659/RR+models+Consistent+rain+melt+Output#RRmodelsConsistentrain+meltOutput-LASAM

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
