### PR TITLE
updated groundwater_to_stream_recharge unit

### DIFF
--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -175,6 +175,8 @@ private:
     double volQ_gw_timestep_m;
     double volPET_timestep_m;
     double mass_balance_m;
+    double volQ_gw_timestep_m3_per_s;
+    double catchment_area_m2;
   };
 
   struct bmi_unit_conversion bmi_unit_conv;

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -147,7 +147,7 @@ private:
   void realloc_soil();
   struct model_state* state;
   static const int input_var_name_count  = 3;
-  static const int output_var_name_count = 17;
+  static const int output_var_name_count = 18;
   static const int calib_var_name_count  = 7;
   
   std::string input_var_names[input_var_name_count];

--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -62,6 +62,7 @@ public:
     this->output_var_names[14] = "mass_balance";
     this->output_var_names[15] = NWM_PONDED_DEPTH_OUT_VAR;
     this->output_var_names[16] = "precipitation_rate_out";
+    this->output_var_names[17] = "groundwater_to_stream_recharge_m3_per_s";
     
     /*
     this->output_var_names[13] = "cum_precipitation";

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -876,7 +876,7 @@ GetVarUnits(std::string name)
   else if (name.compare("total_discharge") == 0 || name.compare("infiltration") == 0
 	   || name.compare("percolation") == 0) // double
     return "m";
-  else if (name.compare("groundwater_to_stream_recharge") == 0)
+  else if (name.compare("mass_balance") == 0 || name.compare("groundwater_to_stream_recharge") == 0)
     return "m";
   else if (name.compare("groundwater_to_stream_recharge_m3_per_s") == 0)
     return "m3 s-1";

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -919,7 +919,8 @@ GetVarLocation(std::string name)
 	   || name.compare("soil_storage") == 0 || name.compare(NWM_PONDED_DEPTH_OUT_VAR)) // double
     return "node";
    else if (name.compare("total_discharge") == 0 || name.compare("infiltration") == 0
-	    || name.compare("percolation") == 0 || name.compare("groundwater_to_stream_recharge") == 0) // double
+	    || name.compare("percolation") == 0 || name.compare("groundwater_to_stream_recharge") == 0
+            || name.compare("groundwater_to_stream_recharge_m3_per_s") == 0) //double
     return "node";
   else if (name.compare("soil_moisture_wetting_fronts") == 0) // array of doubles
     return "node";

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -69,7 +69,7 @@ Initialize (std::string config_file)
   }
 
   bmi_unit_conv.volQ_gw_timestep_m3_per_s = 0.0;
-  bmi_unit_conv.catchment_area_m2 = 1.0;
+  bmi_unit_conv.catchment_area_m2 = 0.0;
 
 }
 
@@ -607,9 +607,15 @@ Update()
   bmi_unit_conv.volrunoff_timestep_m  = volrunoff_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volQ_timestep_m       = volQ_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volQ_gw_timestep_m    = volQ_gw_timestep_cm * state->units.cm_to_m;
-  bmi_unit_conv.volQ_gw_timestep_m3_per_s =
-    (bmi_unit_conv.volQ_gw_timestep_m * bmi_unit_conv.catchment_area_m2) /
-    this->GetTimeStep();
+  if (bmi_unit_conv.catchment_area_m2 > 0.0 && this->GetTimeStep() > 0.0) {
+    bmi_unit_conv.volQ_gw_timestep_m3_per_s =
+      (bmi_unit_conv.volQ_gw_timestep_m * bmi_unit_conv.catchment_area_m2) /
+      this->GetTimeStep();
+  }
+  else {
+    bmi_unit_conv.volQ_gw_timestep_m3_per_s = 0.0;
+  }
+
   bmi_unit_conv.volPET_timestep_m     = PET_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volrunoff_giuh_timestep_m = volrunoff_giuh_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volrunoff_giuh_ponded_m = volrunoff_giuh_ponded_cm * state->units.cm_to_m;

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -786,6 +786,7 @@ GetVarGrid(std::string name)
     || name.compare("infiltration") == 0
 	  || name.compare("percolation") == 0
     || name.compare("groundwater_to_stream_recharge") == 0
+    || name.compare("groundwater_to_stream_recharge_m3_per_s") == 0
     || name.compare("mass_balance") == 0
     || name.compare(NWM_PONDED_DEPTH_OUT_VAR) == 0
     || name.compare("reset_time") == 0
@@ -876,6 +877,8 @@ GetVarUnits(std::string name)
 	   || name.compare("percolation") == 0) // double
     return "m";
   else if (name.compare("groundwater_to_stream_recharge") == 0)
+    return "m";
+  else if (name.compare("groundwater_to_stream_recharge_m3_per_s") == 0)
     return "m3 s-1";
   else if (name.compare("mass_balance") == 0)
     return "m";
@@ -1029,6 +1032,8 @@ GetValuePtr (std::string name)
   else if (name.compare("percolation") == 0)
     return (void*)(&bmi_unit_conv.volrech_timestep_m);
   else if (name.compare("groundwater_to_stream_recharge") == 0)
+    return (void*)(&bmi_unit_conv.volQ_gw_timestep_m);
+  else if (name.compare("groundwater_to_stream_recharge_m3_per_s") == 0)
     return (void*)(&bmi_unit_conv.volQ_gw_timestep_m3_per_s);
   else if (name.compare("mass_balance") == 0)
     return (void*)(&bmi_unit_conv.mass_balance_m);

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -68,6 +68,9 @@ Initialize (std::string config_file)
     giuh_runoff_queue[i] = 0.0;
   }
 
+  bmi_unit_conv.volQ_gw_timestep_m3_per_s = 0.0;
+  bmi_unit_conv.catchment_area_m2 = 1.0;
+
 }
 
 /**
@@ -126,6 +129,7 @@ Update()
     bmi_unit_conv.volrunoff_timestep_m  = state->lgar_bmi_input_params->precipitation_mm_per_h * mm_to_m;
     bmi_unit_conv.volQ_timestep_m       = state->lgar_bmi_input_params->precipitation_mm_per_h * mm_to_m;
     bmi_unit_conv.volQ_gw_timestep_m    = 0.0;
+    bmi_unit_conv.volQ_gw_timestep_m3_per_s = 0.0;
     bmi_unit_conv.volPET_timestep_m     = 0.0;
     bmi_unit_conv.volrunoff_giuh_timestep_m = 0.0;
     bmi_unit_conv.volrunoff_giuh_ponded_m = 0.0;
@@ -603,6 +607,9 @@ Update()
   bmi_unit_conv.volrunoff_timestep_m  = volrunoff_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volQ_timestep_m       = volQ_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volQ_gw_timestep_m    = volQ_gw_timestep_cm * state->units.cm_to_m;
+  bmi_unit_conv.volQ_gw_timestep_m3_per_s =
+    (bmi_unit_conv.volQ_gw_timestep_m * bmi_unit_conv.catchment_area_m2) /
+    this->GetTimeStep();
   bmi_unit_conv.volPET_timestep_m     = PET_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volrunoff_giuh_timestep_m = volrunoff_giuh_timestep_cm * state->units.cm_to_m;
   bmi_unit_conv.volrunoff_giuh_ponded_m = volrunoff_giuh_ponded_cm * state->units.cm_to_m;
@@ -868,7 +875,9 @@ GetVarUnits(std::string name)
   else if (name.compare("total_discharge") == 0 || name.compare("infiltration") == 0
 	   || name.compare("percolation") == 0) // double
     return "m";
-  else if (name.compare("mass_balance") == 0 || name.compare("groundwater_to_stream_recharge") == 0)
+  else if (name.compare("groundwater_to_stream_recharge") == 0)
+    return "m3 s-1";
+  else if (name.compare("mass_balance") == 0)
     return "m";
   else if (name.compare("soil_moisture_wetting_fronts") == 0) // array of doubles
     return "none";
@@ -1020,7 +1029,7 @@ GetValuePtr (std::string name)
   else if (name.compare("percolation") == 0)
     return (void*)(&bmi_unit_conv.volrech_timestep_m);
   else if (name.compare("groundwater_to_stream_recharge") == 0)
-    return (void*)(&bmi_unit_conv.volQ_gw_timestep_m);
+    return (void*)(&bmi_unit_conv.volQ_gw_timestep_m3_per_s);
   else if (name.compare("mass_balance") == 0)
     return (void*)(&bmi_unit_conv.mass_balance_m);
   else if (name.compare(NWM_PONDED_DEPTH_OUT_VAR) == 0)


### PR DESCRIPTION

https://jira.nextgenwaterprediction.com/browse/NGWPC-10214

**Issue**

groundwater_to_stream_recharge was originally exposed in m (depth per timestep), while NWM expects m³/s (discharge) for qBucket, causing: Unable to convert m to m3/s

**Fix**

A new BMI output variable was introduced: groundwater_to_stream_recharge_m3_per_s → m³/s
Computed as:
q = depth × catchment_area / timestep
The original variable remains unchanged:
groundwater_to_stream_recharge → m

**Why**
Preserves LASAM native semantics (depth remains depth)
Avoids repurposing existing variables
Aligns with NWM discharge requirements (qBucket)
Maintains consistency with updates in CFE and Sac-SMA

**Result**
Eliminates unit conversion warning
Produces physically correct discharge output
Maintains backward compatibility and clarity

**Final Mapping**
Variable	Meaning	Units
groundwater_to_stream_recharge	groundwater recharge depth	m
groundwater_to_stream_recharge_m3_per_s