### PR TITLE
Fix for incorrectly identified log messages

### DIFF
--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -1,13 +1,17 @@
 #ifndef LASAM_LOGGER_HPP
 #define LASAM_LOGGER_HPP
 
-#include "ewts/logger.hpp"
 #include "ewts/module_constants.hpp"
+#include "ewts/logger.hpp"
+#include "ewts/log_levels.hpp"
+
+#define LOG(...) ::ewts::GetLogger(::ewts::modules::EWTS_ID_LASAM).Log(__VA_ARGS__)
+#define GetLogLevel() ::ewts::GetLogger(::ewts::modules::EWTS_ID_LASAM).GetLogLevel()
+#define IsLoggingEnabled() ::ewts::GetLogger(::ewts::modules::EWTS_ID_LASAM).IsLoggingEnabled()
 
 using ewts::EwtsInit;
 using ewts::LogLevel;
 
-// Provide the constant in the global namespace:
-inline constexpr const char* EWTS_ID_LASAM = ewts::modules::EWTS_ID_LASAM;
+inline constexpr const char* LASAM_MODULE_ID = ewts::modules::EWTS_ID_LASAM;
 
 #endif /* LASAM_LOGGER_HPP */

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -39,9 +39,9 @@ Initialize (std::string config_file)
 {
     // Initialize the Error, Warning and Trapping System
 #ifdef EWTS_HAVE_NGEN_BRIDGE    
-  EwtsInit(EWTS_ID_LASAM, true);
+  EwtsInit(LASAM_MODULE_ID, true);
 #else
-  EwtsInit(EWTS_ID_LASAM, false);
+  EwtsInit(LASAM_MODULE_ID, false);
 #endif
 
   LOG("Inside BmiLGAR::Initialize \n", LogLevel::INFO);  


### PR DESCRIPTION
Define LOG in submodule instead of relying on generic definition in ewts library which was causing log messages to be incorrectly identified in the logs.