### PR TITLE
Fix Memory Error After State Save Load (NGWPC-10966)

### DIFF
--- a/include/bmi_lgar.hxx
+++ b/include/bmi_lgar.hxx
@@ -186,7 +186,9 @@ private:
   void serialize(Archive& ar, const unsigned int version);
   template<class Archive>
   void serialize_wetting_front_list(Archive &ar, wetting_front **head, int &count);
-  
+  template<class Archive>
+  void serialize_c_array(Archive &ar, double **array, int *size);
+
   void new_serialized();
   void load_serialized(char* data);
   void free_serialized();

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -47,9 +47,7 @@ Initialize (std::string config_file)
 
   LOG("Inside BmiLGAR::Initialize \n", LogLevel::INFO);  
   if (config_file.compare("") != 0 ) {
-    this->state = new model_state;
-    state->head = NULL;
-    state->state_previous = NULL;
+    this->state = static_cast<model_state *>(calloc(1, sizeof(model_state)));
     lgar_initialize(config_file, state);
   }
 
@@ -739,31 +737,35 @@ update_calibratable_parameters()
 void BmiLGAR::
 Finalize()
 {
+  if (!state)
+    return;
   global_mass_balance();
   listDelete(state->head);
   listDelete(state->state_previous);
+  #define DELETE_ARRAY(prop) if (prop) delete[] prop;
+  DELETE_ARRAY(state->soil_properties)
 
-  delete [] state->soil_properties;
+  DELETE_ARRAY(state->lgar_bmi_params.soil_depth_wetting_fronts)
+  DELETE_ARRAY(state->lgar_bmi_params.soil_moisture_wetting_fronts)
 
-  delete [] state->lgar_bmi_params.soil_depth_wetting_fronts;
-  delete [] state->lgar_bmi_params.soil_moisture_wetting_fronts;
+  DELETE_ARRAY(state->lgar_bmi_params.soil_temperature)
+  DELETE_ARRAY(state->lgar_bmi_params.soil_temperature_z)
+  DELETE_ARRAY(state->lgar_bmi_params.layer_soil_type)
 
-  delete [] state->lgar_bmi_params.soil_temperature;
-  delete [] state->lgar_bmi_params.soil_temperature_z;
-  delete [] state->lgar_bmi_params.layer_soil_type;
+  DELETE_ARRAY(state->lgar_calib_params.theta_e)
+  DELETE_ARRAY(state->lgar_calib_params.theta_r)
+  DELETE_ARRAY(state->lgar_calib_params.vg_n)
+  DELETE_ARRAY(state->lgar_calib_params.vg_alpha)
+  DELETE_ARRAY(state->lgar_calib_params.Ksat)
 
-  delete [] state->lgar_calib_params.theta_e;
-  delete [] state->lgar_calib_params.theta_r;
-  delete [] state->lgar_calib_params.vg_n;
-  delete [] state->lgar_calib_params.vg_alpha;
-  delete [] state->lgar_calib_params.Ksat;
-
-  delete [] state->lgar_bmi_params.layer_thickness_cm;
-  delete [] state->lgar_bmi_params.cum_layer_thickness_cm;
-  delete [] state->lgar_bmi_params.giuh_ordinates;
-  delete [] state->lgar_bmi_params.frozen_factor;
-  delete state->lgar_bmi_input_params;
-  delete state;
+  DELETE_ARRAY(state->lgar_bmi_params.layer_thickness_cm)
+  DELETE_ARRAY(state->lgar_bmi_params.cum_layer_thickness_cm)
+  DELETE_ARRAY(state->lgar_bmi_params.giuh_ordinates)
+  DELETE_ARRAY(state->lgar_bmi_params.frozen_factor)
+  #undef DELETE_ARRAY
+  if (state->lgar_bmi_input_params)
+    delete state->lgar_bmi_input_params;
+  free(state);
   this->state = NULL;
 }
 
@@ -1398,14 +1400,14 @@ serialize(Archive& ar, const unsigned int version) {
   ar & state->lgar_mass_balance.volrunoff_giuh_cm;
   ar & state->lgar_mass_balance.volchange_calib_cm;
 
-  ar & boost::serialization::make_array(state->lgar_bmi_params.cum_layer_thickness_cm, state->lgar_bmi_params.num_layers);
+  this->serialize_c_array(ar, &state->lgar_bmi_params.cum_layer_thickness_cm, &state->lgar_bmi_params.num_layers);
 
   // giuh state
-  ar & boost::serialization::make_array(this->giuh_runoff_queue, state->lgar_bmi_params.num_giuh_ordinates);
+  this->serialize_c_array(ar, &this->giuh_runoff_queue, &state->lgar_bmi_params.num_giuh_ordinates);
 
   // in frozen_factor_hydraulic_conductivity
   if (state->lgar_bmi_params.sft_coupled) {
-    ar & boost::serialization::make_array(state->lgar_bmi_params.frozen_factor, state->lgar_bmi_params.num_layers);
+    this->serialize_c_array(ar, &state->lgar_bmi_params.frozen_factor, &state->lgar_bmi_params.num_layers);
   }
 
   // update_calibratable_parameters
@@ -1424,7 +1426,7 @@ serialize(Archive& ar, const unsigned int version) {
   // serialization of arbitrarily-lengthed linked-lists
   int num_fronts = state->lgar_bmi_params.num_wetting_fronts;
   this->serialize_wetting_front_list(ar, &state->head, state->lgar_bmi_params.num_wetting_fronts);
-  int num_previous = 0;
+  int num_previous = 0; // 0 forces a recalculation in the serialize_wetting_front_list function
   this->serialize_wetting_front_list(ar, &state->state_previous, num_previous);
 
   if (Archive::is_loading::value && num_fronts != state->lgar_bmi_params.num_wetting_fronts) {
@@ -1437,7 +1439,20 @@ serialize(Archive& ar, const unsigned int version) {
   ar & boost::serialization::make_array(
     state->lgar_bmi_params.soil_depth_wetting_fronts, state->lgar_bmi_params.num_wetting_fronts
   );
+}
 
+template <class Archive>
+void BmiLGAR::serialize_c_array(Archive &ar, double **array, int *size) {
+  // store and check the size of the stored array to ensure loading doesn't start writing to out-of-bounds addresses
+  int size_copy = *size;
+  ar & *size;
+  if (Archive::is_loading::value) {
+    if (size_copy != *size) {
+      delete[] *array;
+      *array = new double[*size];
+    }
+  }
+  ar & boost::serialization::make_array(*array, *size);
 }
 
 template <class Archive>

--- a/src/bmi_lgar.cxx
+++ b/src/bmi_lgar.cxx
@@ -1433,6 +1433,7 @@ serialize(Archive& ar, const unsigned int version) {
     // reallocate arrays based on new num_wetting_fronts
     this->realloc_soil();
   }
+  // size of wetting fronts controlled above, so no need for overhead of serialize_c_array
   ar & boost::serialization::make_array(
     state->lgar_bmi_params.soil_moisture_wetting_fronts, state->lgar_bmi_params.num_wetting_fronts
   );
@@ -1474,6 +1475,7 @@ void BmiLGAR::serialize_wetting_front_list(Archive &ar, wetting_front **head, in
     wetting_front *prior;
     for (int i = 0; i < count; ++i) {
       current = new wetting_front();
+      current->next = NULL;
       ar & (*current);
       if (i == 0) {
         *head = current;


### PR DESCRIPTION
Addresses some potential memory problems.

## Additions

- (De)serialization of C arrays will include the size of the array. This allows reallocation the array if the loaded data is a different size and would otherwise lead to writing out-of-bounds.
- Initialization of the backing model uses `calloc` to ensure pointers are initialized as `NULL`.
- Finalize checks all C arrays are not `NULL` before attempting to `delete[]`.
- Generation of new `wetting_front`s during deserialization ensures the linked list always ends in `NULL`.

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
